### PR TITLE
fix: Enforce CSV format when dumping importances

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FeatureScreening"
 uuid = "81355843-3c2b-48ff-a0b2-a7573f067e8f"
 authors = ["Cursor Insight <info@cursorinsight.com>"]
-version = "0.19.1"
+version = "0.19.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/FeatureScreening.jl
+++ b/src/FeatureScreening.jl
@@ -145,7 +145,7 @@ function screen(feature_set::AbstractFeatureSet{L, N, F};
         importances::Vector{Pair{N, <: Real}} =
             feature_importance(to_be_selected; config, rng)
 
-        @dump importances path="importances.$i.csv"
+        @dump importances path="importances.$i.csv" mime=MIME("text/csv")
 
         important_names::Vector{<: N} =
             select(importances, Top(reduced_size); strict = false) .|> label


### PR DESCRIPTION
Explicitly setting text/csv as the mime type forces Julia to save the contents of a Dict as a CSV file, which is exactly what we want (instead of the value dump).