### PR TITLE
feat: Revamp feature selection strategies

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -17,11 +17,34 @@ uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 [[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
+[[deps.ChainRulesCore]]
+deps = ["Compat", "LinearAlgebra", "SparseArrays"]
+git-tree-sha1 = "c6d890a52d2c4d55d326439580c3b8d0875a77d9"
+uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+version = "1.15.7"
+
+[[deps.ChangesOfVariables]]
+deps = ["ChainRulesCore", "LinearAlgebra", "Test"]
+git-tree-sha1 = "844b061c104c408b24537482469400af6075aae4"
+uuid = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
+version = "0.1.5"
+
 [[deps.Compat]]
 deps = ["Dates", "LinearAlgebra", "UUIDs"]
 git-tree-sha1 = "61fdd77467a5c3ad071ef8277ac6bd6af7dd4c04"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
 version = "4.6.0"
+
+[[deps.DataAPI]]
+git-tree-sha1 = "e8119c1a33d267e16108be441a287a6981ba1630"
+uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
+version = "1.14.0"
+
+[[deps.DataStructures]]
+deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
+git-tree-sha1 = "d1fff3a548102f48987a52a2e0d114fa97d730f0"
+uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+version = "0.18.13"
 
 [[deps.Dates]]
 deps = ["Printf"]
@@ -46,6 +69,12 @@ deps = ["Dates", "Printf"]
 git-tree-sha1 = "9c2681389ed8d9cf6193b1ba31796f12456b111a"
 uuid = "968ba79b-81e4-546f-ab3a-2eecfa62a9db"
 version = "0.5.0"
+
+[[deps.DocStringExtensions]]
+deps = ["LibGit2"]
+git-tree-sha1 = "2fb1e02f2b635d0845df5d7c167fec4dd739b00d"
+uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+version = "0.9.3"
 
 [[deps.Downloads]]
 deps = ["ArgTools", "LibCURL", "NetworkOptions"]
@@ -74,6 +103,17 @@ version = "1.12.2+2"
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[deps.InverseFunctions]]
+deps = ["Test"]
+git-tree-sha1 = "49510dfcb407e572524ba94aeae2fced1f3feb0f"
+uuid = "3587e190-3f89-42d0-90ee-14403ec27112"
+version = "0.1.8"
+
+[[deps.IrrationalConstants]]
+git-tree-sha1 = "7fd44fd4ff43fc60815f8e764c0f352b83c49151"
+uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
+version = "0.1.1"
 
 [[deps.JLLWrappers]]
 deps = ["Preferences"]
@@ -104,6 +144,12 @@ uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 deps = ["Libdl"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
+[[deps.LogExpFunctions]]
+deps = ["ChainRulesCore", "ChangesOfVariables", "DocStringExtensions", "InverseFunctions", "IrrationalConstants", "LinearAlgebra"]
+git-tree-sha1 = "680e733c3a0a9cea9e935c8c2184aea6a63fa0b5"
+uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
+version = "0.3.21"
+
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
@@ -121,6 +167,12 @@ uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
 
+[[deps.Missings]]
+deps = ["DataAPI"]
+git-tree-sha1 = "f66bdc5de519e8f8ae43bdc598782d35a25b1272"
+uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
+version = "1.1.0"
+
 [[deps.Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
@@ -135,6 +187,11 @@ deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
 git-tree-sha1 = "9ff31d101d987eb9d66bd8b176ac7c277beccd09"
 uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
 version = "1.1.20+0"
+
+[[deps.OrderedCollections]]
+git-tree-sha1 = "85f8e6578bf1f9ee0d11e7bb1b1456435479d47c"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.4.1"
 
 [[deps.Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
@@ -185,6 +242,12 @@ uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 [[deps.Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 
+[[deps.SortingAlgorithms]]
+deps = ["DataStructures"]
+git-tree-sha1 = "a4ada03f999bd01b3a25dcaa30b2d929fe537e00"
+uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
+version = "1.1.0"
+
 [[deps.SparseArrays]]
 deps = ["LinearAlgebra", "Random"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
@@ -193,6 +256,18 @@ uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 deps = ["LinearAlgebra", "SparseArrays"]
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
+[[deps.StatsAPI]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "f9af7f195fb13589dd2e2d57fdb401717d2eb1f6"
+uuid = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
+version = "1.5.0"
+
+[[deps.StatsBase]]
+deps = ["DataAPI", "DataStructures", "LinearAlgebra", "LogExpFunctions", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "StatsAPI"]
+git-tree-sha1 = "d1bf48bfcc554a3761a133fe3a9bb01488e06916"
+uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+version = "0.33.21"
+
 [[deps.TOML]]
 deps = ["Dates"]
 uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
@@ -200,6 +275,10 @@ uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 [[deps.Tar]]
 deps = ["ArgTools", "SHA"]
 uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+
+[[deps.Test]]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[deps.UUIDs]]
 deps = ["Random", "SHA"]

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]

--- a/README.md
+++ b/README.md
@@ -67,23 +67,32 @@ The third signature uses the *de facto* standard data science API, expecting an
 
 The optional keyword parameters (`options`) of all three methods are:
 
-- `reduced_size::Integer`: Expected number of screened features (right now, this
-  is an upper bound).
-- `step_size::Integer`: Size of each partition.
+- `reduced_size::Integer`: Expected number of screened features (an upper
+  bound); defaults to 1/5th of the number of features. Mutually exclusive with
+  `selection_mode`.
+- `step_size::Integer`: Size of each partition; defaults to 1/10th of the number
+  of features.
+- `selection_mode::SelectionMode`: a mode to pick selected features after
+  importance computation. Mutually exclusive with `reduced_size`. For various
+  selection modes, see details below.
 - `config::NamedTuple`: Parameters of the random forest used for importance
-  computation in each round.
+  computation in each round; with sensible defaults (see `DEFAULT_SCREEN_CONFIG`
+  in the source code for details).
 - `shuffle::Bool`: Whether to shuffle the features before partitioning.
-- `before::Function`: Callback function, which is executed before importance
+- `before::Function`: Callback function, that is executed before importance
   computation and feature selection. It is called with the previously selected
-  features and the actual partition, its return value is ignored.
-- `after::Function`: Callback function, which is executed after importance
+  features and the current partition, its return value is ignored.
+- `after::Function`: Callback function, that is executed after importance
   computation and feature selection. It is called with the selected features,
   its return value is ignored.
 - `rng::Union{AbstractRNG, Integer}`: Random generator or seed to be used.
 
-Note that this function can run for a long time, elapsing time is proportional
-to the number of features and samples, and depends on the forest configuration
-as well.
+Specifying `reduced_size` is equivalent to passing `SelectTop(reduced_size;
+strict = false)` in the `selection_mode` parameter. Both options cannot be
+specified simultaneously.
+
+Note that this function can run for a long time. Runtime is proportional to the
+number of features and samples, and depends on the forest configuration as well.
 
 ```julia
 # Returns a FeatureSet with the screened feature set
@@ -96,6 +105,42 @@ julia> selected_features = screen(X, # features
 julia> names(selected_features)
 julia> features(selected_features)
 ```
+
+### Selection modes
+
+A selection mode is an object encapsulating an item selection strategy. It
+controls the behavior of the `select()` function. Currently, the following
+selection modes are defined:
+
+* `SelectTop(n::Integer)`, `SelectTop(r::Real)`: take the top/first *n* items,
+  or the *r* ratio (0-1) of the total number of items, from the collection.
+
+* `SelectRandom([weights::Function,] n::Integer [; replace::Bool])`,
+  `SelectRandom([weights::Function,] r::Real [; replace::Bool])`: take *n*
+  random items, or the *r* ratio (0-1) of the total number of items, from the
+  collection, with replacement if `replace` is true (defaults to false). The
+  probability of picking a specific item is weighted according to the `weights`
+  function, which receives the collection, and must return a same length vector
+  of corresponding weights. By default, `unit_weights` is used, which assigns
+  equal weights to all items.
+
+* `SelectByImportance(n::Int)`: a specific `SelectRandom` take *n* random items
+  from a collection of `label => importance` pairs with no replacement, such
+  that the importance values serve as weights.
+
+* `ComposedSelectionMode(a, b)`, `a ∘ b`: composes two selection modes, such
+  that it performs selection with selection mode `b` first, and then applies
+  selection mode `a` on the outcome of the former.
+
+All selection modes also accept a `strict` keyword parameter (defaults to true).
+If this is set to true, trying to take more items from the collection than it
+contains results in an error. If `strict` is false, the specified number of
+items is considered an upper bound only, but it is silently clamped between the
+given boundaries.
+
+Custom selection modes may be defined by inheriting from the abstract type
+`SelectionMode`, and defining a method `select(rng::AbstractRNG,
+collection::AbstractVector, selection_mode)` to perform the item selection.
 
 ### `FeatureSet`
 


### PR DESCRIPTION
* rename `Selector` to `SelectionMode`;
* provide an interface analog to `StatsBase.sample()`;
* fix random selection strategy to select without replacement;
* implement `SelectByImportance` and `ComposedSelectionMode`;
* `screen` now optionally accepts a `selection_mode` instead of `reduced_size` as a feature selection strategy.

Further details in the README.md.

Closes #20, closes #23.
